### PR TITLE
Edit note

### DIFF
--- a/src/components/EditItem/EditItem.js
+++ b/src/components/EditItem/EditItem.js
@@ -42,7 +42,8 @@ export class EditItem extends Component {
   toggleCompleted = () => {
     let complete = !this.state.completed
     const {value, id} = this.state
-    this.setState({completed: !this.state.completed})
+    this.setState({completed: complete})
+    this.props.moveCompleted({value, id, completed: complete})
   }
 
   render() {

--- a/src/components/EditItem/EditItem.js
+++ b/src/components/EditItem/EditItem.js
@@ -24,8 +24,12 @@ export class EditItem extends Component {
     this.setState({
       value: e.target.value
     }, () => {this.props.updateItem(this.state)})
-    if(e.key === 'Enter') {
-      this.props.handleSubmit(e)
+  }
+
+  checkKey = (e) => {
+    if(e.keyCode == 13) {
+      e.preventDefault()
+      e.keyCode = 9
     }
   }
 
@@ -54,7 +58,8 @@ export class EditItem extends Component {
               </input>
               {
                 this.state.id &&
-                <textarea onKeyDown={this.updateItem}
+                <textarea onKeyUp={this.updateItem}
+                          onKeyDown={this.checkKey}
                           className="list-item"
                           defaultValue={this.state.value}
                           >

--- a/src/components/EditItem/EditItem.js
+++ b/src/components/EditItem/EditItem.js
@@ -3,12 +3,12 @@ import { connect } from 'react-redux'
 import {changeItem} from '../../actions'
 
 export class EditItem extends Component {
-  constructor({props}) {
-    super({props});
+  constructor(props) {
+    super(props);
     this.state = {
       value: '',
       id: '',
-      completed: '',
+      completed: false,
     }
   }
 
@@ -26,7 +26,8 @@ export class EditItem extends Component {
     })
   }
 
-  editItem = () => {
+  editItem = (e) => {
+    e.preventDefault()
     if(this.state.value) {
       this.props.updateItem(this.state)
     }
@@ -41,32 +42,37 @@ export class EditItem extends Component {
   toggleCompleted = () => {
     let complete = !this.state.completed
     const {value, id} = this.state
-    this.props.updateItem({value, id, complete}, 'completed')
     this.setState({completed: !this.state.completed})
   }
 
   render() {
-    const { value, id, completed } = this.props
-    console.log(this.state)
+    let cardValue;
+    console.log(this.state.value)
+    if(this.state.value) {
+      cardValue = this.state.value
+    }
     return (
-      <div className='list-container' >
-        <input type='checkbox'
-                className='list-control'
-                name='completed'
-                checked={this.state.completed}
-                onChange={this.toggleCompleted}
-                >
-        </input>
-        <textarea onChange={this.updateItem}
-                  className="list-item"
-                  onBlur={this.editItem}
-                  defaultValue={value}
-                  >
-        </textarea>
-        <button className='list-control delete-item' onClick={this.deleteItem}>X</button>
-      </div>
-    )
-  }
+            <div className='list-container' >
+              <input type='checkbox'
+                      className='list-control'
+                      name='completed'
+                      checked={this.state.completed}
+                      onChange={this.toggleCompleted}
+                      >
+              </input>
+              {
+                this.state.id &&
+                <textarea onChange={this.updateItem}
+                          className="list-item"
+                          defaultValue={this.state.value}
+                          >
+                </textarea>
+              }
+              <button onClick={this.editItem}>Edit</button>
+              <button className='list-control delete-item' onClick={this.deleteItem}>X</button>
+            </div>
+         )
+      }
 }
 
 export default EditItem;

--- a/src/components/EditItem/EditItem.js
+++ b/src/components/EditItem/EditItem.js
@@ -24,6 +24,10 @@ export class EditItem extends Component {
     this.setState({
       value: e.target.value
     }, () => {this.props.updateItem(this.state)})
+    if(e.key === 'Enter') {
+      console.log('booop')
+      this.props.handleSubmit(e)
+    }
   }
 
   deleteItem = (e) => {
@@ -51,7 +55,7 @@ export class EditItem extends Component {
               </input>
               {
                 this.state.id &&
-                <textarea onChange={this.updateItem}
+                <textarea onKeyDown={this.updateItem}
                           className="list-item"
                           defaultValue={this.state.value}
                           >

--- a/src/components/EditItem/EditItem.js
+++ b/src/components/EditItem/EditItem.js
@@ -23,14 +23,7 @@ export class EditItem extends Component {
   updateItem = (e) => {
     this.setState({
       value: e.target.value
-    })
-  }
-
-  editItem = (e) => {
-    e.preventDefault()
-    if(this.state.value) {
-      this.props.updateItem(this.state)
-    }
+    }, () => {this.props.updateItem(this.state)})
   }
 
   deleteItem = (e) => {
@@ -64,7 +57,6 @@ export class EditItem extends Component {
                           >
                 </textarea>
               }
-              <button onClick={this.editItem}>Edit</button>
               <button className='list-control delete-item' onClick={this.deleteItem}>X</button>
             </div>
          )
@@ -72,9 +64,3 @@ export class EditItem extends Component {
 }
 
 export default EditItem;
-
-// export const mapDispatchToProps = (dispatch) => ({
-//   changeItem: (item) => dispatch(changeItem(item))
-// })
-
-// export default connect(null, mapDispatchToProps)(EditItem)

--- a/src/components/EditItem/EditItem.js
+++ b/src/components/EditItem/EditItem.js
@@ -25,7 +25,6 @@ export class EditItem extends Component {
       value: e.target.value
     }, () => {this.props.updateItem(this.state)})
     if(e.key === 'Enter') {
-      console.log('booop')
       this.props.handleSubmit(e)
     }
   }

--- a/src/components/NoteContainer/NoteContainer.js
+++ b/src/components/NoteContainer/NoteContainer.js
@@ -3,7 +3,7 @@ import ViewNote from '../../containers/ViewNote/ViewNote'
 
 export const NoteContainer = (props) => {
   // console.log(props.notes)
-  const notes = props.notes.map(note => <ViewNote key={Date.now()} note={note}/>)
+  const notes = props.notes.map(note => <ViewNote key={note.id} note={note}/>)
   return (
     <div>
       {notes}

--- a/src/containers/EditNote/EditNote.js
+++ b/src/containers/EditNote/EditNote.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import { withRouter } from 'react-router-dom'
 import EditItem from '../../components/EditItem/EditItem'
-import NewItem from '../../components/NewItem/NewItem'
 import { addNote, updateNote, removeNote } from '../../helpers/apiCalls'
 import { connect } from 'react-redux'
 import { storeUpdate, deleteNote, storeNote } from '../../actions'
@@ -62,28 +61,25 @@ export class EditNote extends Component {
   }
 
   moveCompleted = (completedItem) => {
+    let newState;
     if(completedItem.completed) {
-      let newState = this.state.items.filter(item => item.id !== completedItem.id)
+      newState = this.state.items.filter(item => item.id !== completedItem.id)
       newState.push(completedItem)
-      this.setState({
-        items: newState,
-      })
     } else {
-      let newState = this.state.items.map(item => {
+      newState = this.state.items.map(item => {
         if(item.id == completedItem.id) {
           item = completedItem
         }
         return item
       })
-      this.setState({
-        items: newState,
-      })
     }
+        this.setState({
+          items: newState,
+        })
   }
 
   handleSubmit = (e) => {
     e.preventDefault()
-    //either call editNote or sendNote
     if(this.state.new === false) {
       this.editNote()
     } else {

--- a/src/containers/EditNote/EditNote.js
+++ b/src/containers/EditNote/EditNote.js
@@ -35,11 +35,10 @@ export class EditNote extends Component {
         return item
       })
       let index = updatedItems.indexOf(newItem)
-      if(!updatedItems[index + 1] && !completed) {
+      if(!updatedItems[index + 1]) {
         this.setState({
           items: [...updatedItems, {value: '', id: Date.now(), completed: false} ]
         })
-        console.log(this.state.items)
       } else {
         this.setState({
           items: updatedItems
@@ -77,15 +76,13 @@ export class EditNote extends Component {
   }
 
   render() {
-    console.log(this.props)
-    const { title, items, id } = this.props
-    console.log(this.state)
+    console.log(this.state.items)
     return (
       <div className="form-container">
         <form onSubmit={this.editNote}>
         <input className='title' 
               // onChange={this.handleChange}
-              value={title}
+              defaultValue={this.state.title}
               name="title"
               placeholder='Title'
               >
@@ -94,12 +91,12 @@ export class EditNote extends Component {
             this.state.items.map(item => <EditItem {...item} 
                                         updateItem={this.updateState}
                                         delete={this.deleteItem}
-                                        key={item.value}
+                                        key={item.id}
                                       /> )
           }
           <div className="note-controls">
           <button className='save-note'>Save</button>
-          <button className='delete-note' onClick={() => this.handleDeleteNote(id)}>X</button>
+          <button className='delete-note' onClick={() => this.handleDeleteNote(this.state.id)}>X</button>
           </div>
         </form>
       </div>
@@ -112,4 +109,4 @@ export const mapDispatchToProps = (dispatch) => ({
   storeUpdate: (note) => dispatch(storeUpdate(note))
 })
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EditNote));
+export default withRouter(connect(null, mapDispatchToProps)(EditNote));

--- a/src/containers/EditNote/EditNote.js
+++ b/src/containers/EditNote/EditNote.js
@@ -47,6 +47,17 @@ export class EditNote extends Component {
     }
   }
 
+  moveCompleted = (completedItem) => {
+    console.log(this.state)
+    if(completedItem.completed) {
+      let newState = this.state.items.filter(item => item.id !== completedItem.id)
+      newState.push(completedItem)
+      this.setState({
+        items: newState,
+      })
+    }
+  }
+
   editNote = async (e) => {
     e.preventDefault()
     const { history } = this.props
@@ -76,7 +87,7 @@ export class EditNote extends Component {
   }
 
   render() {
-    console.log(this.state.items)
+    console.log(this.state)
     return (
       <div className="form-container">
         <form onSubmit={this.editNote}>
@@ -91,6 +102,7 @@ export class EditNote extends Component {
             this.state.items.map(item => <EditItem {...item} 
                                         updateItem={this.updateState}
                                         delete={this.deleteItem}
+                                        moveCompleted={this.moveCompleted}
                                         key={item.id}
                                       /> )
           }

--- a/src/containers/EditNote/EditNote.js
+++ b/src/containers/EditNote/EditNote.js
@@ -157,6 +157,7 @@ export class EditNote extends Component {
                                         updateItem={this.updateState}
                                         delete={this.deleteItem}
                                         moveCompleted={this.moveCompleted}
+                                        handleSubmit={this.handleSubmit}
                                         key={item.id}
                                       /> )
           }

--- a/src/containers/EditNote/EditNote.js
+++ b/src/containers/EditNote/EditNote.js
@@ -43,8 +43,6 @@ export class EditNote extends Component {
   }
 
   updateState = (newItem, completed) => {
-    console.log(this.state)
-    console.log(completed)
     if(this.state.items.length) {
       const updatedItems = this.state.items.map(item => {
         if (item.id == newItem.id) {
@@ -53,24 +51,28 @@ export class EditNote extends Component {
         return item
       })
       let index = updatedItems.indexOf(newItem)
-      if(!updatedItems[index + 1] && !completed) {
-        this.setState({
-          items: [...updatedItems, {value: '', id: Date.now(), completed: false} ]
-        })
-        console.log(this.state.items)
-      } else {
+      
         this.setState({
           items: updatedItems
         })
-      }
+      
     }
   }
 
   moveCompleted = (completedItem) => {
-    console.log(this.state)
     if(completedItem.completed) {
       let newState = this.state.items.filter(item => item.id !== completedItem.id)
       newState.push(completedItem)
+      this.setState({
+        items: newState,
+      })
+    } else {
+      let newState = this.state.items.map(item => {
+        if(item.id == completedItem.id) {
+          item = completedItem
+        }
+        return item
+      })
       this.setState({
         items: newState,
       })
@@ -88,7 +90,6 @@ export class EditNote extends Component {
   }
 
   sendNote = async () => {
-    console.log('fire')
     let { history } = this.props;
     const { title } = this.state
     let items = this.state.items.filter(item => item.value)
@@ -99,7 +100,6 @@ export class EditNote extends Component {
   }
 
   editNote = async () => {
-    
     const { history } = this.props
     let newItems = this.state.items.filter(item => item.value)
     this.setState({
@@ -126,8 +126,22 @@ export class EditNote extends Component {
     history.push('/')
   }
 
+  addItem = (e) => {
+    e.preventDefault()
+    let count = 0;
+    this.state.items.forEach(item => {
+      if(item.completed) {
+        count++
+      }
+    })
+    let indexVal = this.state.items.length - count;
+    this.state.items.splice(indexVal, 0, {value: '', id: Date.now(), completed: false})
+    this.setState({
+      items: this.state.items
+    })
+  }
+
   render() {
-    console.log(this.state)
     return (
       <div className="form-container">
         <form onSubmit={this.handleSubmit}>
@@ -147,7 +161,9 @@ export class EditNote extends Component {
                                       /> )
           }
           <div className="note-controls">
-          <button className='save-note'>Update</button>
+          <button className="save-note"
+                  onClick={this.addItem}>Add An Item</button>
+          <button className='save-note'>Save Note</button>
           <button className='delete-note' onClick={() => this.handleDeleteNote(this.state.id)}>X</button>
           </div>
         </form>

--- a/src/containers/EditNote/EditNote.js
+++ b/src/containers/EditNote/EditNote.js
@@ -39,9 +39,6 @@ export class EditNote extends Component {
     this.setState({
       [e.target.name] : e.target.value
     })
-    if(e.key === 'Enter') {
-      this.handleSubmit(e)
-    }
   }
 
   updateState = (newItem, completed) => {
@@ -60,18 +57,26 @@ export class EditNote extends Component {
   }
 
   moveCompleted = (completedItem) => {
-    let newState;
-    if(completedItem.completed) {
-      newState = this.state.items.filter(item => item.id !== completedItem.id)
-      newState.push(completedItem)
-    } else {
-      newState = this.state.items.map(item => {
-        if(item.id == completedItem.id) {
-          item = completedItem
-        }
-        return item
-      })
-    }
+    // let newState;
+    let newState = this.state.items.map(item => {
+      if(item.id == completedItem.id) {
+        item = completedItem
+      }
+      return item
+    })
+    // if(completedItem.completed) {
+    //   newState = this.state.items.filter(item => item.id !== completedItem.id)
+    //   newState.push(completedItem)
+    // } else {
+    //   newState = this.state.items.filter(item => item.id !== completedItem.id)
+    //   newState.unshift(completedItem)
+    //   // newState = this.state.items.map(item => {
+    //   //   if(item.id == completedItem.id) {
+    //   //     item = completedItem
+    //   //   }
+    //   //   return item
+    //   // })
+    // }
         this.setState({
           items: newState,
         })
@@ -125,38 +130,56 @@ export class EditNote extends Component {
 
   addItem = (e) => {
     e.preventDefault()
-    let count = 0;
-    this.state.items.forEach(item => {
-      if(item.completed) {
-        count++
-      }
-    })
-    let indexVal = this.state.items.length - count;
-    this.state.items.splice(indexVal, 0, {value: '', id: Date.now(), completed: false})
+    this.state.items.push({value: '', id: Date.now(), completed: false})
     this.setState({
       items: this.state.items
     })
   }
 
-  render() {
+  returnItemElement = (item) => <EditItem {...item} 
+                                            updateItem={this.updateState}
+                                            delete={this.deleteItem}
+                                            key={item.id}
+                                            moveCompleted={this.moveCompleted}
+                                            />
+
+  checkKey = (e) => {
+    if(e.keyCode == 13) {
+      e.preventDefault()
+      e.keyCode = 9
+    }
+  }                                        
+                                 
+    render() {
+      let completeItems
+      let incompleteItems
+      let completeElements
+      let incompleteElements
+      if (this.state.items.length) {
+        completeItems = this.state.items.filter(item => item.completed === true)
+        incompleteItems = this.state.items.filter(item => item.completed === false)
+        completeElements = completeItems.map(item => this.returnItemElement(item))
+        incompleteElements = incompleteItems.map(item => this.returnItemElement(item))
+      }
+
+
+
     return (
       <div className="form-container">
         <form onSubmit={this.handleSubmit}>
         <input className='title' 
-              onKeyDown={this.handleChange}
+              onKeyUp={this.handleChange}
+              onKeyDown={this.checkKey}
               defaultValue={this.state.title}
               name="title"
               placeholder='Title'
               >
         </input>
           {this.state.items && 
-            this.state.items.map(item => <EditItem {...item} 
-                                        updateItem={this.updateState}
-                                        delete={this.deleteItem}
-                                        moveCompleted={this.moveCompleted}
-                                        handleSubmit={this.handleSubmit}
-                                        key={item.id}
-                                      /> )
+          <div>
+            {incompleteElements}
+            {completeElements}
+          </div>
           }
           <div className="note-controls">
           <button className="save-note"

--- a/src/containers/EditNote/EditNote.js
+++ b/src/containers/EditNote/EditNote.js
@@ -107,10 +107,6 @@ export class EditNote extends Component {
   }
 }
 
-export const mapStateToProps = (state) => ({
-  notes: state.notes
-})
-
 export const mapDispatchToProps = (dispatch) => ({
   deleteNote: (id) => dispatch(deleteNote(id)),
   storeUpdate: (note) => dispatch(storeUpdate(note))

--- a/src/containers/EditNote/EditNote.js
+++ b/src/containers/EditNote/EditNote.js
@@ -52,7 +52,6 @@ export class EditNote extends Component {
         }
         return item
       })
-      let index = updatedItems.indexOf(newItem)
         this.setState({
           items: updatedItems
         })

--- a/src/containers/EditNote/EditNote.js
+++ b/src/containers/EditNote/EditNote.js
@@ -40,6 +40,9 @@ export class EditNote extends Component {
     this.setState({
       [e.target.name] : e.target.value
     })
+    if(e.key === 'Enter') {
+      this.handleSubmit(e)
+    }
   }
 
   updateState = (newItem, completed) => {
@@ -51,7 +54,6 @@ export class EditNote extends Component {
         return item
       })
       let index = updatedItems.indexOf(newItem)
-      
         this.setState({
           items: updatedItems
         })
@@ -146,7 +148,7 @@ export class EditNote extends Component {
       <div className="form-container">
         <form onSubmit={this.handleSubmit}>
         <input className='title' 
-              onChange={this.handleChange}
+              onKeyDown={this.handleChange}
               defaultValue={this.state.title}
               name="title"
               placeholder='Title'


### PR DESCRIPTION
-Remove "edit" button in each list item. Save edited card, items and completed value, on click "Save Note".
-Change update note state to keydown property.
-Return catches for title and note, saving note and returning to homepage.
-Remove onChange rendering of new inputs in favor of addItem button.
-Move completed items to bottom of note.
-Render new item text areas above completed items.
-Change labels for buttons to be more descriptive.